### PR TITLE
Add GraphQL loader

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -195,11 +195,12 @@ module.exports = {
       // "file" loader makes sure those assets get served by WebpackDevServer.
       // When you `import` an asset, you get its (virtual) filename.
       // In production, they would get copied to the `build` folder.
-      // ZEAL: Add .scss because we add the sass-loader below.
+      // ZEAL: Add .scss and .graphql because we add the loaders below
       {
         exclude: [
           /\.html$/,
           /\.(js|jsx)$/,
+          /\.(graphql|gql)$/,
           /\.css$/,
           /\.scss$/,
           /\.json$/,
@@ -306,6 +307,12 @@ module.exports = {
           },
           require.resolve('sass-loader'),
         ],
+      },
+      // ZEAL: Adds support for parsing GraphQL files
+      {
+        test: /\.(graphql|gql)$/,
+        exclude: /node_modules/,
+        loader: 'graphql-tag/loader',
       },
       // ** STOP ** Are you adding a new loader?
       // Remember to add the new extension(s) to the "file" loader exclusion list.

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -43,6 +43,7 @@
     "extract-text-webpack-plugin": "2.1.0",
     "file-loader": "0.11.1",
     "fs-extra": "3.0.1",
+    "graphql-tag": "^2.4.2",
     "html-webpack-plugin": "2.28.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "20.0.3",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -47,6 +47,7 @@
     "html-webpack-plugin": "2.28.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "20.0.3",
+    "jest-transform-graphql": "^2.1.0",
     "json-loader": "0.5.4",
     "node-sass": "3.13.1",
     "object-assign": "4.1.1",

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -41,6 +41,8 @@ module.exports = (resolve, rootDir, isEjecting) => {
         : resolve('config/jest/babelTransform.js'),
       '^.+\\.css$': resolve('config/jest/cssTransform.js'),
       '^(?!.*\\.(js|jsx|css|json)$)': resolve('config/jest/fileTransform.js'),
+      // ZEAL: Adds support for parsing GraphQL files
+      '^.+\\.(gql|graphql)$': require.resolve('jest-transform-graphql'),
     },
     transformIgnorePatterns: [
       '[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$',

--- a/packages/react-scripts/yarn.lock
+++ b/packages/react-scripts/yarn.lock
@@ -2732,6 +2732,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
+graphql-tag@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.4.2.tgz#6a63297d8522d03a2b72d26f1b239aab343840cd"
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -2956,7 +2960,7 @@ icss-replace-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.0.2.tgz#cb0b6054eb3af6edc9ab1d62d01933e2d4c8bfa5"
 
-identity-obj-proxy@3.0.0:
+identity-obj-proxy@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz#94d2bda96084453ef36fbc5aaec37e0f79f1fc14"
   dependencies:

--- a/packages/react-scripts/yarn.lock
+++ b/packages/react-scripts/yarn.lock
@@ -3551,6 +3551,10 @@ jest-snapshot@^20.0.3:
     natural-compare "^1.4.0"
     pretty-format "^20.0.3"
 
+jest-transform-graphql@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/jest-transform-graphql/-/jest-transform-graphql-2.1.0.tgz#903cb66bb27bc2772fd3e5dd4f7e9b57230f5829"
+
 jest-util@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-20.0.3.tgz#0c07f7d80d82f4e5a67c6f8b9c3fe7f65cfd32ad"


### PR DESCRIPTION
Loads GraphQL queries from .graphql files

- Does not process GraphQL ASTs on client-side
- Enables queries to be separated from logic


http://dev.apollodata.com/react/webpack.html