### PR TITLE
Exlude `graphql` and `gql` from fileTransform pattern

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -38,7 +38,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
         ? '<rootDir>/node_modules/babel-jest'
         : resolve('config/jest/babelTransform.js'),
       '^.+\\.css$': resolve('config/jest/cssTransform.js'),
-      '^(?!.*\\.(js|jsx|mjs|css|json)$)': resolve(
+      '^(?!.*\\.(js|jsx|mjs|css|json|graphql|gql)$)': resolve(
         'config/jest/fileTransform.js'
       ),
       // ZEAL: Adds support for parsing GraphQL files


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

In `packages/react-scripts/scripts/utils/createJestConfig.js` the transform config block contains a pattern to use `fileTransform`.  The regex for that block of code is a catch all for extensions not referenced.  Though `graphql` and `gql` have there own pattern which intends to use the `jest-transform-graphql` module, that pattern is not used because of the aforementioned catch all.  This PR simply adds those extensions to allow them to be caught by the intended loader.

I should also note that in create-react-app on the next branch, there is a commit which does something very similar to the zeal block for `graphql` files.  However in the mean time, `graphql` loading for jest is not working, in that a `graphql` file loaded in jest is converted to a stringified name via the `fileTransform`